### PR TITLE
General improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # moleculer-schema-adapter (MSA)
 
-<p align="justify">An adapter that connects to a Schema service, allowing you to verify and validate communication between services.</p>
+<p align="justify">An adapter that allows events and actions parameters to be validated against JSON schemas.</p>
 
 ## Table of Contents
 
@@ -12,18 +12,17 @@
 
 ## Requirements
 
-MSA assumes that you are using the Moleculer microservice framework, and have a moleculer Schema service. This service should provide valid JSON Schemas via an action (default name: `fetch`), by `id` where `id` should be the name of the schema. MSA is flexible, allowing the developer to set:
+MSA assumes that you are using the Moleculer microservice framework.
 
-- Name of the Schema service, default lookup: `schema`
-- Name of the action, default lookup: `fetch`
-- Wait time (dependency timeout), default value: `10000` (in ms)
+## How it works
+
+When `MSA` loads, it reads the schema directory, validating and caching all schemas. Subsequently, `MSA` chooses the schema to use based on the name of the event or action.
 
 ## Usage
 
-- Require the package
-- Add the middleware to the service configuration
-- Add the mixin to the service
-
+- Require the package;
+- Add the middleware to the service configuration;
+- Add the mixin to the service;
 
 ## Distribution
 

--- a/errors.js
+++ b/errors.js
@@ -1,0 +1,55 @@
+//////
+// Custome typed and named errors
+//////
+
+"use strict";
+
+const {
+	MoleculerError
+} = require("moleculer").Errors;
+
+const PATH_FAILED_READ_DIRECTORY = class PATH_FAILED_READ_DIRECTORY extends MoleculerError {
+	constructor(pathDirectory, error) {
+		const msg = `Failed to read content of directory: ${pathDirectory}`;
+		console.error(`${msg} Error:`, error);
+		super(msg, 500, "PATH_FAILED_READ_DIRECTORY", error);
+	}
+};
+
+const PATH_FAILED_TO_PROCESS_SCHEMA = class PATH_FAILED_TO_PROCESS_SCHEMA extends MoleculerError {
+	constructor(schemaName, error) {
+		const msg = `Failed to process schema "${schemaName}"`;
+		console.error(`${msg} Error:`, error);
+		super(msg, 500, "PATH_FAILED_TO_PROCESS_SCHEMA", error);
+	}
+};
+
+const SCHEMA_INVALID = class SCHEMA_INVALID extends MoleculerError {
+	constructor(error) {
+		const msg = "Invalid schema.";
+		console.error(`${msg} Error:`, error);
+		super(msg, 500, "SCHEMA_INVALID", error);
+	}
+};
+
+const INVALID_PAYLOAD = class INVALID_PAYLOAD extends MoleculerError {
+	constructor(schemaName, error) {
+		const msg = `Invalid payload. Using "${schemaName}" schema.`;
+		console.error(`${msg} Error:`, error);
+		super(msg, 500, "INVALID_PAYLOAD", error);
+	}
+};
+
+const MISSING_SCHEMA = class MISSING_SCHEMA extends MoleculerError {
+	constructor(action) {
+		super(`Missing ${action} schema! Was that loaded?`);
+	}
+};
+
+module.exports = {
+	PATH_FAILED_READ_DIRECTORY,
+	PATH_FAILED_TO_PROCESS_SCHEMA,
+	SCHEMA_INVALID,
+	INVALID_PAYLOAD,
+	MISSING_SCHEMA
+};

--- a/helpers.js
+++ b/helpers.js
@@ -7,7 +7,7 @@ const ajv = Ajv({
 	allErrors: true
 });
 
-const CNE = require("./errors");
+const Errors = require("./errors");
 
 /**
  * Process(validate, and cache) a schema.
@@ -19,7 +19,7 @@ const CNE = require("./errors");
  * @throws {SCHEMA_INVALID}
  */
 const processSchema = (ctx, schemaName, schema) => {
-	if (!ajv.validateSchema(schema)) throw new CNE.SCHEMA_INVALID(ajv.errors, null);
+	if (!ajv.validateSchema(schema)) throw new Errors.SCHEMA_INVALID(ajv.errors, null);
 
 	// AJV: It isn't possible to manually cache schemas (in-memory), as such
 	// functionality isn't exposed via the API, but calling `compile` will
@@ -71,7 +71,7 @@ const loadAllSchemasFromDisk = (ctx, schemasDirectory) => {
 			)
 		);
 	} catch (error) {
-		throw new CNE.PATH_FAILED_READ_DIRECTORY(resolvedDirectoryPath, error);
+		throw new Errors.PATH_FAILED_READ_DIRECTORY(resolvedDirectoryPath, error);
 	}
 
 	// Process each schema: validate, and cache
@@ -79,7 +79,7 @@ const loadAllSchemasFromDisk = (ctx, schemasDirectory) => {
 		try {
 			processSchema(ctx, schemaName, schema);
 		} catch (error) {
-			throw new CNE.PATH_FAILED_TO_PROCESS_SCHEMA(schemaName, error);
+			throw new Errors.PATH_FAILED_TO_PROCESS_SCHEMA(schemaName, error);
 		}
 	});
 };

--- a/helpers.js
+++ b/helpers.js
@@ -1,0 +1,89 @@
+"use strict";
+
+const requireDir = require("require-dir");
+const path = require("path");
+const Ajv = require("ajv");
+const ajv = Ajv({
+	allErrors: true
+});
+
+const CNE = require("./errors");
+
+/**
+ * Process(validate, and cache) a schema.
+ *
+ * @param {Object} ctx context
+ * @param {string} schemaName schema name
+ * @param {string} schema valid JSON schema
+ *
+ * @throws {SCHEMA_INVALID}
+ */
+const processSchema = (ctx, schemaName, schema) => {
+	if (!ajv.validateSchema(schema)) throw new CNE.SCHEMA_INVALID(ajv.errors, null);
+
+	// AJV: It isn't possible to manually cache schemas (in-memory), as such
+	// functionality isn't exposed via the API, but calling `compile` will
+	// create the cache.
+	//
+	// Note that `compile` also performs validation, but if the schema is
+	// invalid, AJV will automatically throw errors. I purposely split the
+	// process into two steps, to gain more fine-grained controls.
+	ajv.compile(schema);
+
+	// Cache schema
+	if (ctx && Object.keys(ctx).includes("broker")) {
+		ctx.logger.info(`Cached ${schemaName}`);
+
+		// Cache in-memory
+		ctx.settings.schemas[schemaName] = schema;
+
+		// Only cache if it's set
+		if (
+			Object.keys(ctx.broker).includes("cacher") &&
+			ctx.broker.cacher
+		) ctx.broker.cacher.set(schemaName, schema);
+	}
+
+	return schema;
+};
+
+/**
+ * Load all schemas from a given directory.
+ *
+ * @param {Object} ctx context
+ * @param {string} schemasDirectory path to the schemas directory
+ *
+ * @throws {PATH_FAILED_READ_DIRECTORY}
+ * @throws {PATH_FAILED_TO_PROCESS_SCHEMA}
+ */
+const loadAllSchemasFromDisk = (ctx, schemasDirectory) => {
+	let schemasMap;
+
+	const resolvedDirectoryPath = path.resolve(schemasDirectory);
+
+	// Load schemas
+	try {
+		schemasMap = new Map(
+			Object.entries(
+				requireDir(resolvedDirectoryPath, {
+					extensions: [".ts", ".js"]
+				})
+			)
+		);
+	} catch (error) {
+		throw new CNE.PATH_FAILED_READ_DIRECTORY(resolvedDirectoryPath, error);
+	}
+
+	// Process each schema: validate, and cache
+	schemasMap.forEach((schema, schemaName) => {
+		try {
+			processSchema(ctx, schemaName, schema);
+		} catch (error) {
+			throw new CNE.PATH_FAILED_TO_PROCESS_SCHEMA(schemaName, error);
+		}
+	});
+};
+
+module.exports = {
+	loadAllSchemasFromDisk
+};

--- a/index.js
+++ b/index.js
@@ -8,167 +8,15 @@
  * middlewares array and the mixin to the mixin array.
  */
 
+"use strict";
+
 const Ajv = require("ajv");
 const ajv = Ajv({
 	allErrors: true
 });
-const path = require("path");
-const fs = require("fs");
-const {
-	ValidationError,
-	MoleculerError
-} = require("moleculer").Errors;
 
-//////
-// Custome Names Errors
-//////
-
-const PATH_DIRECTORY_DOES_NOT_EXIST = class PATH_DIRECTORY_DOES_NOT_EXIST extends MoleculerError {
-	constructor(pathDirectory, error) {
-		super(
-			`Directory doesn't exists: ${pathDirectory}`,
-			500,
-			"PATH_DIRECTORY_DOES_NOT_EXIST",
-			error
-		);
-	}
-};
-const PATH_FILE_DOES_NOT_EXIST = class PATH_FILE_DOES_NOT_EXIST extends MoleculerError {
-	constructor(pathFile, error) {
-		super(
-			`File doesn't exists: ${pathFile}`,
-			500,
-			"PATH_FILE_DOES_NOT_EXIST",
-			error
-		);
-	}
-};
-const PATH_FAILED_READ_DIRECTORY = class PATH_FAILED_READ_DIRECTORY extends MoleculerError {
-	constructor(pathDirectory, error) {
-		super(
-			`Failed to read content of directory: ${pathDirectory}`,
-			500,
-			"PATH_FAILED_READ_DIRECTORY",
-			error
-		);
-	}
-};
-const SCHEMA_INVALID = class SCHEMA_INVALID extends MoleculerError {
-	constructor(error) {
-		super("Invalid schema", 500, "SCHEMA_INVALID", error);
-	}
-};
-
-const MISSING_SCHEMA = class MISSING_SCHEMA extends MoleculerError {
-	constructor(action) {
-		super(`${action} requires a schema to validate the payload. Request has been refused.`);
-	}
-};
-
-const MISSING_SCHEMA_DIR_ENV_VAR = class MISSING_SCHEMA_DIR_ENV_VAR extends MoleculerError {
-	constructor() {
-		super("Is SCHEMA_DIR defined?");
-	}
-};
-
-//////
-// Convenience functions
-// @see https://softwareengineering.stackexchange.com/a/272812
-//////
-
-/**
- * Load the specified schema from the FS.
- *
- * @param {Object} ctx context
- * @param {string} schemasDirectory schemas directory
- * @param {string} schemaName schema name
- *
- * @throws {PATH_DIRECTORY_DOES_NOT_EXIST}
- * @throws {PATH_FILE_DOES_NOT_EXIST}
- * @throws {SCHEMA_INVALID}
- *
- * @returns {Object} schema
- */
-const loadSchemaFromDisk = (ctx, schemasDirectory, schemaName) => {
-	// Build, normalize (Windows/*nix compatible), and resolve the path to the
-	// schema directory
-	const schemaPath = `${schemasDirectory}/${schemaName}.js`;
-	const normalizedSchemaPath = path.normalize(schemaPath);
-	const resolvedSchemaPath = path.resolve(normalizedSchemaPath);
-
-	// Safe guards:
-	// - Validate directory
-	// - Validate file
-	if (!fs.existsSync(normalizedSchemaPath))
-		throw new PATH_DIRECTORY_DOES_NOT_EXIST(schemasDirectory, null);
-	if (!fs.existsSync(resolvedSchemaPath))
-		throw new PATH_FILE_DOES_NOT_EXIST(schemasDirectory, null);
-
-	// Safe guard:
-	// - Validate schema
-	//
-	// Load schema from FS, and validate
-	const schema = require(resolvedSchemaPath);
-	const isValid = ajv.validateSchema(schema);
-
-	if (!isValid) throw new SCHEMA_INVALID(ajv.errors, null);
-
-	// AJV: It isn't possible to manually cache schemas (in-memory), as such
-	// functionality isn't exposed via the API, but calling `compile` will
-	// create the cache.
-	//
-	// Note that `compile` also performs validation, but if the schema is
-	// invalid, AJV will automatically throw errors. I purposely split the
-	// process into two steps, to gain more fine-grained controls.
-	ajv.compile(schema);
-
-	// Cache at service level, via Moleculer Broker Cacher (redis)
-	if (ctx && Object.keys(ctx).includes("broker")) {
-		ctx.logger.info(`Cached ${schemaName}`);
-		ctx.broker.cacher.set(schemaName, schema);
-		ctx.settings.schemas[schemaName] = schema;
-	}
-
-	return schema;
-};
-
-/**
- * Load all schemas in a given directory
- *
- * @param {Object} ctx context
- * @param {string} schemasDirectory schemas directory
- *
- * @throws {PATH_FAILED_READ_DIRECTORY}
- *
- * @returns {Array<Object>} schemas
- */
-const loadAllSchemasFromDisk = (ctx, schemasDirectory) => {
-	// Build path
-	const normalizedDirectoryPath = path.normalize(schemasDirectory);
-	const resolvedDirectoryPath = path.resolve(normalizedDirectoryPath);
-	const schemas = [];
-
-	try {
-		const listOfFilenames = fs.readdirSync(resolvedDirectoryPath);
-		const setOfFilenamesWithoutExtension = new Set();
-
-		listOfFilenames.forEach(filename => {
-			setOfFilenamesWithoutExtension.add(
-				filename.substring(0, filename.indexOf(".js"))
-			);
-		});
-
-		// Deduplication by using `Set`
-		// @see scripts/benchmark-loadAllSchemasFromDisk.js
-		setOfFilenamesWithoutExtension.forEach(entry => {
-			schemas.push(loadSchemaFromDisk(ctx, schemasDirectory, entry));
-		});
-	} catch (error) {
-		throw new PATH_FAILED_READ_DIRECTORY(resolvedDirectoryPath, error);
-	}
-
-	return schemas;
-};
+const helpers = require("./helpers");
+const CNE = require("./errors");
 
 //////
 // Starts here
@@ -177,34 +25,30 @@ const loadAllSchemasFromDisk = (ctx, schemasDirectory) => {
 /**
  * Moleculer Schema Adaptor factory
  *
- * @param {string} [schemaServiceName=schema] Moleculer Schema service name
- * @param {string} [actionName=fetch] Action to call
  * @param {Object} [settings]
+ * @param {string} [settings.schemaDir="schemas"] Schemas folder
  */
 const MoleculerSchemaAdaptor = settings => {
-	// TODO: Settings can be used later to wire in a notification type service
+	// Default values
 	if (!settings) settings = {};
-	Object.assign(settings, {});
+
+	Object.assign(settings, {
+		schemaDir: "schemas"
+	});
 
 	return {
 		middleware: {
-			// Listen to all incoming events
+			// Listen and validates all incoming events
 			localEvent(next, broker) {
 				return (payload, sender, topic) => {
-					// Call method
-					broker.service
-						.validateEvent(payload, sender, topic)
-						// Validation succeed :)
-						.then(() => {})
-						// Validation failed :(
-						.catch(error => {
-							this.logger.error(
-								"middleware::localEvent::return::validateEvent::invalid",
-								error
-							);
-
-							// TODO: Also handle rejection by calling the Notification Service
-						});
+					try {
+						broker.service.validateEvent(payload, sender, topic);
+					} catch (error) {
+						this.logger.error(
+							"middleware::localEvent::return::validateEvent::invalid",
+							error
+						);
+					}
 
 					return next(payload, sender, topic);
 				};
@@ -215,70 +59,56 @@ const MoleculerSchemaAdaptor = settings => {
 		// When a service uses mixins, all properties in the mixin will be “mixed”, merged,
 		// into the current service.
 		mixin: {
-			// The Moleculer Service constructor merges these mixins with the current schema.
-			// When a service uses mixins, all properties in the mixin will be “mixed”, merged,
-			// into the current service.
 			settings: {
 				// Schemas will be stored here. This will act as an in-memory cache.
 				schemas: {},
 			},
 			hooks: {
 				before: {
-					// All actions are processed through the validateAction hook.  If a schema
-					// is available, the request will be validated.
+					// All actions are processed through the validateAction hook.
+					// If a schema is available, the request will be validated.
 					"*": "validateAction"
 				}
 			},
 			actions: {
 				listSchemas() {
-					return this.settings.schemas || []
+					return this.settings.schemas || [];
 				}
 			},
-			// Wait for the Schema service be up and running
-			// dependencies: [schemaServiceName],
 			methods: {
 				/**
 				 * Validate the event payload against the matching schema
 				 *
 				 * @param {Object} payload incoming data
-				 * @param {string} sender service that send the event
-				 * @param {string} eventName evnt name
+				 * @param {string} sender caller
+				 * @param {string} eventName event name
 				 *
-				 * @throws {ValidationError}
-				 *
-				 * @returns {Promise}
+				 * @throws {INVALID_PAYLOAD}
+				 * @throws {MISSING_SCHEMA}
 				 */
 				validateEvent(payload, sender, eventName) {
-					return new Promise((resolve, reject) => {
+					if (this.settings.schemas[eventName]) {
 						if (
 							!ajv.validate(
 								this.settings.schemas[eventName],
 								payload
 							)
 						) {
-							return reject(
-								new ValidationError(
-									`${sender} emitted an invalid payload for the ${eventName} event`,
-									ajv.errors
-								)
-							);
+							throw new CNE.INVALID_PAYLOAD(eventName, ajv.errors);
 						}
-
-						return resolve();
-					});
+					} else {
+						throw new CNE.MISSING_SCHEMA(eventName);
+					}
 				},
 				/**
 				 * Validate the action payload against the matching schema
 				 *
-				 * @param {Object} payload incoming data
-				 * @param {string} sender service that send the event
-				 * @param {string} eventName evnt name
+				 * @param {Object} ctx action context
 				 *
-				 * @throws {ValidationError}
-				 *
-				 * @returns {Promise}
+				 * @throws {INVALID_PAYLOAD}
+				 * @throws {MISSING_SCHEMA}
 				 */
-				async validateAction(ctx) {
+				validateAction(ctx) {
 					const actionName = ctx.action.name;
 
 					if (this.settings.schemas[actionName]) {
@@ -288,27 +118,16 @@ const MoleculerSchemaAdaptor = settings => {
 								ctx.params
 							)
 						) {
-							throw new ValidationError(
-								`Invalid payload for the ${actionName} event`,
-								ajv.errors
-							);
+							throw new CNE.INVALID_PAYLOAD(actionName, ajv.errors);
 						}
 					} else {
-						throw new MISSING_SCHEMA(actionName);
+						throw new CNE.MISSING_SCHEMA(actionName);
 					}
 				},
-
-				loadAllSchemasFromDisk: loadAllSchemasFromDisk,
-				loadSchemaFromDisk: loadSchemaFromDisk
 			},
 			// Service lifecycle hook
 			started() {
-				if (process.env.SCHEMA_DIR && path.resolve(process.env.SCHEMA_DIR)) {
-					console.log("======================= LOADING SERVICE SCHEMAS =======================");
-					loadAllSchemasFromDisk(this, process.env.SCHEMA_DIR);
-				} else {
-					throw new MISSING_SCHEMA_DIR_ENV_VAR();
-				}
+				helpers.loadAllSchemasFromDisk(this, settings.schemaDir);
 			}
 		}
 	};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrecking-ball-software/moleculer-schema-adapter",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1371,6 +1371,11 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true
+    },
+    "require-dir": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/require-dir/-/require-dir-1.2.0.tgz",
+      "integrity": "sha512-LY85DTSu+heYgDqq/mK+7zFHWkttVNRXC9NKcKGyuGLdlsfbjEPrIEYdCVrx6hqnJb+xSu3Lzaoo8VnmOhhjNA=="
     },
     "resolve": {
       "version": "1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,35 +1,36 @@
 {
-  "name": "@wrecking-ball-software/moleculer-schema-adapter",
-  "version": "0.0.2",
-  "description": "An adapter that connects to a Schema service, allowing you to verify and validate communication between services.",
-  "main": "index.js",
-  "repository": {
-    "type": "git",
-    "url": "git@github.com:WreckingBallStudioLabs/moleculer-schema-adapter.git"
-  },
-  "keywords": [
-    "moleculer",
-    "mixin",
-    "adaptor",
-    "middleware",
-    "schema"
-  ],
-  "author": "Thales Pinheiro <thales@bravocognos.com>",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/WreckingBallStudioLabs/moleculer-schema-adapter/issues"
-  },
-  "homepage": "https://github.com/WreckingBallStudioLabs/moleculer-schema-adapter#readme",
-  "devDependencies": {
-    "babel-eslint": "^10.0.3",
-    "eslint": "^6.2.2",
-    "eslint-plugin-import": "^2.18.2"
-  },
-  "dependencies": {
-    "ajv": "^6.10.2",
-    "moleculer": "^0.13.10"
-  },
-  "engines": {
-    "node": ">= 12.x.x"
-  }
+    "name": "@wrecking-ball-software/moleculer-schema-adapter",
+    "version": "0.1.0",
+    "description": "An adapter that allows events and actions parameters to be validated against JSON schemas",
+    "main": "index.js",
+    "repository": {
+        "type": "git",
+        "url": "git@github.com:WreckingBallStudioLabs/moleculer-schema-adapter.git"
+    },
+    "keywords": [
+        "moleculer",
+        "mixin",
+        "adaptor",
+        "middleware",
+        "schema"
+    ],
+    "author": "Thales Pinheiro <thales@bravocognos.com>",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/WreckingBallStudioLabs/moleculer-schema-adapter/issues"
+    },
+    "homepage": "https://github.com/WreckingBallStudioLabs/moleculer-schema-adapter#readme",
+    "devDependencies": {
+        "babel-eslint": "^10.0.3",
+        "eslint": "^6.2.2",
+        "eslint-plugin-import": "^2.18.2"
+    },
+    "dependencies": {
+        "ajv": "^6.10.2",
+        "moleculer": "^0.13.10",
+        "require-dir": "^1.2.0"
+    },
+    "engines": {
+        "node": ">= 12.x.x"
+    }
 }


### PR DESCRIPTION
- Moved `errors` to their own place.
- Improved `errors` output, for example for an invalid payload:
```
[
  {
    keyword: 'required',
    dataPath: '',
    schemaPath: '#/required',
    params: { missingProperty: 'adapters' },
    message: "should have required property 'adapters'"
  }
]
```
- Moved `helpers` to their own place.
- Updated outdated documentation (JSDoc).
- Removed external dependency (`Redis`).
- Fixed bug that would halt application if `Redis` was not set.
- Removed dependency on any ENV VAR (`SCHEMA_DIR`). Now a setting is available, with default values ​​set. This also frees services that import `msa` from declaring any ENV VAR.
- Removed any `asynchronous / promise 'as it is no longer needed.
- ESLinted (added `;`), code has been formatted.
- Fixed bug in `validateEvent` that was calling a schema without previously checking if the schema was there.
- Now using a `Map` to store schema information, better and cleaner.