### PR TITLE
Fixes the hardcoded schema directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,12 +29,11 @@ const CNE = require("./errors");
  * @param {string} [settings.schemaDir="schemas"] Schemas folder
  */
 const MoleculerSchemaAdaptor = settings => {
-	// Default values
-	if (!settings) settings = {};
 
-	Object.assign(settings, {
-		schemaDir: "schemas"
-	});
+	// Default values
+	if (!settings) settings = {
+		schemaDir: process.env.SCHEMA_DIR || "schemas"
+	};
 
 	return {
 		middleware: {


### PR DESCRIPTION
Schema directory value was being hardcoded.  This change defaults the schema directory value to an environment variable if it exists, if not it defaults to `schemas`.